### PR TITLE
Checkbox setState bug example

### DIFF
--- a/examples/webpack-example/src/app/components/CheckboxExample.jsx
+++ b/examples/webpack-example/src/app/components/CheckboxExample.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import Checkbox from 'material-ui/lib/checkbox';
+
+const CheckboxExample = React.createClass({
+  getInitialState() {
+    return {
+      foo: 'buzz',
+    };
+  },
+
+  _handleOnCheck() {
+    // NOTE: If you do not call setState here, the checkbox will toggle normally
+    this.setState({
+      foo: 'boats',
+    });
+  },
+
+  render() {
+    return (
+      <div>
+        <Checkbox
+          label="My Checkbox"
+          onCheck={this._handleOnCheck} />
+      </div>
+    );
+  },
+});
+
+export default CheckboxExample;

--- a/examples/webpack-example/src/app/components/main.jsx
+++ b/examples/webpack-example/src/app/components/main.jsx
@@ -8,6 +8,8 @@ import LightRawTheme from 'material-ui/lib/styles/raw-themes/light-raw-theme';
 import Colors from 'material-ui/lib/styles/colors';
 import FlatButton from 'material-ui/lib/flat-button';
 
+import CheckboxExample from './CheckboxExample';
+
 const containerStyle = {
   textAlign: 'center',
   paddingTop: 200,
@@ -74,6 +76,7 @@ const Main = React.createClass({
         <h1>material-ui</h1>
         <h2>example project</h2>
         <RaisedButton label="Super Secret Password" primary={true} onTouchTap={this._handleTouchTap} />
+        <CheckboxExample />
       </div>
     );
   },


### PR DESCRIPTION
If the function used in the `onCheck` property calls `setState`, the Checkbox will not toggle properly.
